### PR TITLE
Exit with non-zero on lexical error

### DIFF
--- a/asm.l
+++ b/asm.l
@@ -80,7 +80,7 @@
 \n                          { return LF; }
 "/"                         { return SLASH; }
 [\t\r\f ]                   { ; }
-.                           { fprintf(stderr, "wsi: unrecognized token at line %d: `%c'", yylineno, *yytext); }
+.                           { fprintf(stderr, "wsi: unrecognized token at line %d: `%c'", yylineno, *yytext); exit(1); }
 
 %%
 


### PR DESCRIPTION
A small fix to make sure all error paths exit with non-zero. Only one case was missed.